### PR TITLE
Fix dictionary path fallback

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,6 +15,9 @@ async def lifespan(app: FastAPI):
     openai_api_key = os.getenv('OPENAI_API_KEY')
     project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
     dictionary_path = os.path.join(project_root, "frontend/public/dictionary.json")
+    if not os.path.exists(dictionary_path):
+        # Fallback to repository root dictionary
+        dictionary_path = os.path.join(project_root, "latin_dictionary.json")
     cache_db = os.path.join(project_root, "word_cache.db")
     
     app.state.enhanced_dictionary = EnhancedDictionary(

--- a/enhanced_dictionary.py
+++ b/enhanced_dictionary.py
@@ -214,8 +214,12 @@ class LatinMorphologyAnalyzer:
 class EnhancedDictionary:
     """Enhanced dictionary with morphological analysis and OpenAI integration"""
     
-    def __init__(self, dictionary_path: str = "frontend/public/dictionary.json", 
+    def __init__(self, dictionary_path: str = "frontend/public/dictionary.json",
                  openai_api_key: str = None, cache_db: str = "word_cache.db"):
+        # Resolve dictionary path and provide fallback
+        if not os.path.exists(dictionary_path):
+            fallback = os.path.join(os.path.dirname(__file__), "latin_dictionary.json")
+            dictionary_path = fallback
         self.dictionary_path = dictionary_path
         self.cache_db = cache_db
         self.analyzer = LatinMorphologyAnalyzer()


### PR DESCRIPTION
## Summary
- fallback to latin_dictionary.json if frontend dictionary is missing
- ensure EnhancedDictionary checks for fallback path during init

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68432cc8ba4c83279dc770cfac3b82f6